### PR TITLE
Bump build number to 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 003e91162a0ff8ea4f1e501838ae0ff8636614fe5fca63c18036ffb87c0b41ff
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
This should ensure that we have a build compatible with osqp-eigen 0.7.0 .