### PR TITLE
Bump version to v4.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "idyntree" %}
-{% set version = "4.3.1" %}
+{% set version = "4.4.0" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ source:
   sha256: 003e91162a0ff8ea4f1e501838ae0ff8636614fe5fca63c18036ffb87c0b41ff
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
The bump to v5.0.0 will be done by the bot, but it is a good idea to have a binary also for v4.4.0 .