### PR TITLE
Remove pip and related dependencies from host

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [ppc64le]
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -38,10 +38,7 @@ requirements:
     - eigen
     - glfw
     - irrlicht
-    - pip
-    - python-build
     - python
-    - cmake-build-extension
     - numpy
     - libosqp
     - osqp-eigen


### PR DESCRIPTION
Since https://github.com/conda-forge/idyntree-feedstock/pull/20/files the python bindings are installed with pure cmake, so we should have removed also the related dependencies.

This fixes the linter error in https://github.com/conda-forge/idyntree-feedstock/pull/100#issuecomment-2306086992 .